### PR TITLE
Soporte para Sentencias Condicionales (if/else) en TypeEasy

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -50,7 +50,7 @@ typedef enum {
     VAL_STRING,
     VAL_FLOAT,
     VAL_OBJECT
-} ValueType;
+} ValueType; 
 
 typedef struct ObjectNode ObjectNode;
 
@@ -133,6 +133,7 @@ ASTNode *create_function_call_node(const char *funcName, ASTNode *args);
 
 ASTNode *add_statement(ASTNode *list, ASTNode *stmt);
 ASTNode *create_ast_node(char *type, ASTNode *left, ASTNode *right);
+ASTNode *create_if_node(ASTNode* condition, ASTNode* if_branch, ASTNode* else_branch);
 ASTNode *create_ast_leaf(char *type, int value, char *str_value, char *id);
 ASTNode *create_ast_leaf_number(char *type, int value, char *str_value, char *id);
 ASTNode *create_ast_node_for(char *type, ASTNode *var, ASTNode *init, ASTNode *condition, ASTNode *update, ASTNode *body);

--- a/src/parser.l
+++ b/src/parser.l
@@ -66,6 +66,8 @@
 "*"                     { return MULTIPLY; }
 "/"                     { return DIVIDE; }
 "="                     { return ASSIGN; }
+"if"                    { return IF; }    
+"else"                  { return ELSE; }  
 
 
 \"(\\.|[^\"])*\"      {

--- a/typeeasycode/test_if.te
+++ b/typeeasycode/test_if.te
@@ -1,0 +1,31 @@
+/*
+  * Archivo: test_if
+  * Descripcion: Ejemplo básico de uso de if-else en TypeEasy
+  * Autor: Luis Howard
+  * Fecha: 2025-10-07
+*/
+
+// Declaración de variables
+let x = 10;
+let y = 5;
+
+// -------------------------------- Ejemplo de if-else------------------------------------------
+if(x > y) {
+    println("x es mayor que y");
+} else {
+    println("x es menor o igual que y");
+} 
+
+//---------------------------- Comprobamos si x es diferente de y ----------------------------
+if(x != y) {
+    println("x es diferente de y");
+}
+
+// Modificamos el valor de x
+x = 5;
+
+//---------------------------- Comprobamos si x es igual a y -----------------------------------
+if(x == y) {
+    println("x es igual a y");
+} 
+


### PR DESCRIPTION
Esta solicitud de extracción añade soporte para las sentencias `if` y `else `al lenguaje **TypeEasy**, permitiendo la ejecución condicional en los programas de usuario. 
```
// Declaración de variables
let x = 10;
let y = 5;

// -------------------------------- Ejemplo de if-else------------------------------------------
if(x > y) {
    println("x es mayor que y");
} else {
    println("x es menor o igual que y");
} 

```

Los cambios incluyen actualizaciones del analizador léxico y sintáctico para reconocer las palabras clave if y else, nuevo tipo de nodos AST y constructores para sentencias condicionales, lógica de interpretación para evaluar condiciones y ejecutar ramas, y un nuevo archivo de prueba que demuestra la funcionalidad.
